### PR TITLE
スペースの出力部分の修正

### DIFF
--- a/programs/main.js
+++ b/programs/main.js
@@ -164,12 +164,12 @@ function processCode(code) {
         console.log(`Tab: ${tabCount}`);
         let words = line.split(/(\s+|(?=[^\w\s])|(?<=[^\w\s]))/g).filter(Boolean);
         words.forEach(word => {
-            if (word === '\t' || word % 4 === 0) {
-                for (let i = 0; i < tabCount; i++) {
-                    let newToken = createToken('\t', tk_type.TK_TAB, lineNumber, tokenNumber('\t'));
-                    console.log(`Line: ${newToken.lineNumber} Type: ${tokenTypeToString(newToken.type)} Value: /t Number: ${newToken.tkNumber}`);
-                }
-            } else {
+            if (/\s{4,}/.test(word) && word.length % 4 === 0) {
+                    for (let i = 0; i < tabCount; i++) {
+                        let newToken = createToken('\t', tk_type.TK_TAB, lineNumber, tokenNumber('\t'));
+                        console.log(`Line: ${newToken.lineNumber} Type: ${tokenTypeToString(newToken.type)} Value: /t Number: ${newToken.tkNumber}`);
+                    }
+            } else if(!/\s{1,}/.test(word)) {
                 let type = getTokenType(word);
                 let newToken = createToken(word, type, lineNumber, tokenNumber(word));
                 console.log(`Line: ${newToken.lineNumber} Type: ${tokenTypeToString(newToken.type)} Value: ${newToken.word} Number: ${newToken.tkNumber}`);


### PR DESCRIPTION
for x in y:
    for y in z:
        print(z)
のようなコードを入力したときに空白文字を１つでも読み込むとタブのカウント数'/t'と表示されていたので、main.js内での
(/\s{4,}/.test(word) && word.length % 4 === 0)を条件式にすることで空白文字4つと判定することができる。また、その他のものを出力するときにも誤って出力されないように(!/\s{1,}/.test(word))としている。