### PR TITLE
デザインの仮設定

### DIFF
--- a/programs/ace.js
+++ b/programs/ace.js
@@ -7,7 +7,7 @@ function editorInit() {
     editor = ace.edit("editor");
     editor.setTheme("ace/theme/monokai"); // テーマを設定
     editor.session.setMode("ace/mode/python"); // 言語モードを設定
-    editor.setFontSize(14); // フォントサイズを設定
+    editor.setFontSize(18); // フォントサイズを設定
     editor.getSession().setTabSize(4); // タブサイズを設定
     editor.getSession().setUseWrapMode(true); // 折り返し表示を設定
 }

--- a/programs/index.html
+++ b/programs/index.html
@@ -7,9 +7,10 @@
 </head>
 <body>
     <div id="editor"></div>
-    <button id = run>実行</button>
-    <p>＜字句解析＞</p>
-    <div id="output">
+    <button id="run">実行</button>
+    <div id="result" font-size: 18px><p>＜構文解析ログ＞</p></div>
+    <div id="output" font-size: 18px>
+        <p>＜字句解析＞</p>
         <table id="tokenTable">
             <thead>
                 <tr>
@@ -23,6 +24,7 @@
             <tbody></tbody>
         </table>
     </div>
+    <div id="execute" font-size: 18px><p>＜実行結果＞</p></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ace.js"></script>
     <script src="ace.js"></script>
     <script src="scanner.js"></script>

--- a/programs/parser.js
+++ b/programs/parser.js
@@ -1,4 +1,5 @@
 let pushRun_parser = document.getElementById("run");
+let resultDiv = document.getElementById("result"); // 追加
 
 let currentTokenIndex = 0;
 let tokens = [];
@@ -6,66 +7,46 @@ let token;
 let nestedLevel;
 let nestedLevel_t;
 
+function appendToResult(message, isError = false) {
+    let resultElement = document.createElement('p');
+    resultElement.textContent = message;
+    if (isError) {
+        resultElement.style.color = 'red'; // エラーメッセージを赤くする
+    }
+    resultDiv.appendChild(resultElement);
+}
+
 function tokenName(tokenNumber) {
     switch (tokenNumber) {
-        case 2:
-            return tk_type.TK_INTEGER;
-        case 3:
-            return tk_type.TK_FLOAT;
-        case 4:
-            return tk_type.TK_STRING;
-        case 5:
-            return tk_type.TK_PRINT;
-        case 6:
-            return tk_type.TK_L_PAR;
-        case 7:
-            return tk_type.TK_R_PAR;
-        case 8:
-            return tk_type.TK_COMMA;
-        case 9:
-            return tk_type.TK_EQUAL;
-        case 10:
-            return tk_type.TK_COLON;
-        case 11:
-            return tk_type.TK_L_INDEX;
-        case 12:
-            return tk_type.TK_R_INDEX;
-        case 13:
-            return tk_type.TK_FOR;
-        case 14:
-            return tk_type.TK_IN;
-        case 15:
-            return tk_type.TK_RANGE;
-        case 16:
-            return tk_type.TK_TAB;
-        case 17:
-            return tk_type.TK_ENTER;
-        case 18:
-            return tk_type.TK_SEPARATOR;
-        case 19:
-            return tk_type.TK_END;
-        case 20:
-            return tk_type.TK_IF;
-        case 21:
-            return tk_type.TK_ELIF;
-        case 22:
-            return tk_type.TK_ELSE;
-        case 23:
-            return tk_type.TK_WHILE;
-        case 24:
-            return tk_type.TK_L_BRACE;
-        case 25:
-            return tk_type.TK_R_BRACE;
-        case 26:
-            return tk_type.TK_PLUS;
-        case 27:
-            return tk_type.TK_MINUS;
-        case 28:
-            return tk_type.TK_MULTIPLY;
-        case 29:
-            return tk_type.TK_DIVIDE;
-        default:
-            return tk_type.TK_IDENTIFIER;
+        case 2: return tk_type.TK_INTEGER;
+        case 3: return tk_type.TK_FLOAT;
+        case 4: return tk_type.TK_STRING;
+        case 5: return tk_type.TK_PRINT;
+        case 6: return tk_type.TK_L_PAR;
+        case 7: return tk_type.TK_R_PAR;
+        case 8: return tk_type.TK_COMMA;
+        case 9: return tk_type.TK_EQUAL;
+        case 10: return tk_type.TK_COLON;
+        case 11: return tk_type.TK_L_INDEX;
+        case 12: return tk_type.TK_R_INDEX;
+        case 13: return tk_type.TK_FOR;
+        case 14: return tk_type.TK_IN;
+        case 15: return tk_type.TK_RANGE;
+        case 16: return tk_type.TK_TAB;
+        case 17: return tk_type.TK_ENTER;
+        case 18: return tk_type.TK_SEPARATOR;
+        case 19: return tk_type.TK_END;
+        case 20: return tk_type.TK_IF;
+        case 21: return tk_type.TK_ELIF;
+        case 22: return tk_type.TK_ELSE;
+        case 23: return tk_type.TK_WHILE;
+        case 24: return tk_type.TK_L_BRACE;
+        case 25: return tk_type.TK_R_BRACE;
+        case 26: return tk_type.TK_PLUS;
+        case 27: return tk_type.TK_MINUS;
+        case 28: return tk_type.TK_MULTIPLY;
+        case 29: return tk_type.TK_DIVIDE;
+        default: return tk_type.TK_IDENTIFIER;
     }
 }
 
@@ -81,11 +62,14 @@ function parseTokens(tokenList) {
     tokens = tokenList;
     currentTokenIndex = 0;
     token = null; // トークンをリセット
+     // 結果表示エリアをリセット
+     resultDiv.innerHTML = '＜構文解析ログ＞';
+
     try {
         parseProgram();
-        console.log("構文解析成功");
+        appendToResult("正常に終了しました");
     } catch (error) {
-        console.error("構文エラー: " + error.message);
+        appendToResult(token.lineNumber + "行目  構文エラー: " + error.message, true);
     }
 }
 
@@ -122,6 +106,7 @@ function parseStatement() {
         case tk_type.TK_ENTER:
             break;
         default:
+            appendToResult(token.word);
             throw new Error("不明な文です: " + token.tokenNumber);
     }
 }
@@ -196,7 +181,6 @@ function parseElseStatement() {
 
 function parseForStatement() {
     token = getNextToken();
-    console.log(token.word);
     if (token.type !== tk_type.TK_IDENTIFIER) {
         throw new Error("識別子が必要です");
     }
@@ -381,7 +365,9 @@ function parseIndentedStatements() {
         throw new Error("インデントが必要です");
     }
     parseStatement();
-    token = getNextToken();
+    if(token.type !== tk_type.TK_ENTER){
+        token = getNextToken();
+    }   
 }
 
 function parseIndentedStatementsSecond() {

--- a/programs/styles.css
+++ b/programs/styles.css
@@ -1,37 +1,78 @@
-#editor {
-    width: 100%;
-    height: 300px;
-    border: 1px solid #ccc;
-    font-size: 14px;
-    margin-bottom: 10px;
-}
-
+/* 全体をリセット */
 body {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
     font-family: Arial, sans-serif;
 }
 
+/* エディタ部分の配置 */
 #editor {
-    width: 100%;
-    height: 300px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 50%;
+    height: 50%;
+    border: 1px solid #ccc;
 }
 
+/* 実行結果の配置 */
+#run {
+    position: absolute;
+    bottom: 44.5vh;
+    left: 0;
+    width: 8%;
+    height: 5%;
+    border: 2px solid #0a0a0a;
+    overflow-y: auto;
+    font-size: 18px;
+}
+
+/* 構文解析ログの配置 */
+#result {
+    position: absolute;
+    bottom: 15vh;
+    left: 0;
+    width: 50%;
+    height: 25%;
+    border: 3px solid #080cf1;
+    overflow-y: auto;
+    font-size: 18px;
+}
+
+/* 字句解析の配置 */
 #output {
-    margin-top: 20px;
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 48%;
+    height: 50%;
+    border: 3px solid #08f02e;
+    overflow-y: auto;
 }
 
-table {
+#tokenTable {
     width: 100%;
     border-collapse: collapse;
 }
 
-th, td {
+#tokenTable th, #tokenTable td {
     border: 1px solid #ddd;
     padding: 8px;
     text-align: left;
 }
 
-th {
-    background-color: #f2f2f2;
+#execute {
+    position: absolute;
+    bottom: 15vh;
+    right: 0;
+    width: 48%;
+    height: 30%;
+    border: 3px solid #f04a08;
+    overflow-y: auto;
+    font-size: 18px;
 }
 
 


### PR DESCRIPTION
html上で確認できるようにページのデザインの仮設定を行った。
editorを左上、構文解析の結果を左下、字句解析結果を右上に
実行結果を未実装であるが右下になるような仮デザインにした。